### PR TITLE
Fixed error when cloning "responsive" repository and the "core" submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "core"]
+	path = core
+	url = https://github.com/cyberchimps/responsivecore


### PR DESCRIPTION
When cloning the responsive project from github I got the following error both at home and at school.

```
Submodule 'core' (git@github.com:cyberchimps/responsivecore.git) registered for path 'core'
Cloning into 'core'...
Warning: Permanently added the RSA host key for IP address '192.30.252.130' to the list of known hosts.
Permission denied (publickey).
fatal: The remote end hung up unexpectedly
Clone of 'git@github.com:cyberchimps/responsivecore.git' into submodule path 'core' failed
```

First of all the IP adress is local so probably available for some but not for everyone. The strange part is that I didn't find where it's located in the git repository, it must be there somewhere. The second thing is that just checking out the repository automatically added a RSA host key to my known_hosts which is a bit scary but that is perhaps more of a git issue than a problem with this repository.

Anyhow. I manually removed all links to the core submodule (according to these instruction http://davidwalsh.name/git-remove-submodule) and then added them back. So git only shows the change from "git" urls to "https" but I've tried to clone my own fork and the core submodule is cloned properly now.

For debugging purpose, I use the following command when I clone the responsive repository from my fork.

```
git clone -o github --recursive https://github.com/christofferholmstedt/responsive responsiveTest
```

I assume you use ssh keys inhouse for development but this would make it easier for others to clone.
