### PR TITLE
remove the RPST install notice in the theme customizer

### DIFF
--- a/admin/templates/getting-started-home.php
+++ b/admin/templates/getting-started-home.php
@@ -201,6 +201,8 @@ $responsive_addons_state = Responsive_Plugin_Install_Helper::instance()->check_p
 
 	$responsive_addons_cards_content = array(
 		array(
+			// WP-6871 This part add Free batch on Dashboard > Responsive Plus feature cards (no longer needed)
+			// 'tag'   => 'free',
 			'title' => __( 'Starter Templates', 'responsive' ),
 			'desc'  => __( 'Unlock the library of 100+ Premium Starter Templates.', 'responsive' ),
 			'links' => array(
@@ -212,6 +214,8 @@ $responsive_addons_state = Responsive_Plugin_Install_Helper::instance()->check_p
 			),
 		),
 		array(
+			// WP-6871 This part add Free batch on Dashboard > Responsive Plus feature cards (no longer needed)
+			// 'tag'   => 'free',
 			'title' => __( 'White Label', 'responsive' ),
 			'desc'  => __( 'White Label the theme name & settings with the Pro Plugin.', 'responsive' ),
 			'links' => array(
@@ -395,6 +399,12 @@ $responsive_addons_state = Responsive_Plugin_Install_Helper::instance()->check_p
 								<span class="responsive-theme-feature-card responsive-theme-feature-card-<?php echo esc_html( $feature['tag'] ); ?>"><span><?php echo esc_html( $feature['tag'] ); ?></span></span>
 								<?php
 							}
+							// WP-6871 This part add Free batch on Dashboard > Responsive Plus feature cards (no longer needed)
+							// if ( 'pro' !== $feature['tag'] ) {
+							// 	?>
+							<!-- // 	<span class="responsive-theme-feature-card responsive-theme-feature-card-<?php // echo esc_html( $feature['tag'] ); ?>"><span><?php // echo esc_html( $feature['tag'] ); ?></span></span> -->
+							  <?php
+							// }
 							?>
 							<div class="responsive-theme-feature-card-title mt-2 mb-2"><?php echo esc_html( $feature['title'] ); ?></div>
 							<div class="responsive-theme-feature-card-desc"><?php echo esc_html( $feature['desc'] ); ?></div>
@@ -467,9 +477,14 @@ $responsive_addons_state = Responsive_Plugin_Install_Helper::instance()->check_p
 							if ( check_is_responsive_pro_activated() ) {
 								?>
 							<span class="responsive-theme-feature-card responsive-theme-feature-card-pro"><span><?php esc_html_e( 'PRO', 'responsive' ); ?></span></span>
-								<?php
+							<?php 
 							}
 							?>
+							<!-- WP-6871 This part add Free batch on Dashboard > Responsive Plus feature cards (no longer needed) -->
+							<!-- <?php
+							// } else {
+								?> -->
+							<!-- <span class="responsive-theme-feature-card responsive-theme-feature-card-free"><span><?php //esc_html_e( 'FREE', 'responsive' ); ?></span></span> -->
 							<div class="responsive-theme-feature-card-title mt-2 mb-2"><?php echo esc_html_e( 'Mega Menu', 'responsive' ); ?></div>
 							<div class="responsive-theme-feature-card-desc"><?php echo esc_html_e( 'Adds menu options such as mega menus, highlight tags, icons, etc.', 'responsive' ); ?></div>
 							<?php
@@ -659,9 +674,14 @@ $responsive_addons_state = Responsive_Plugin_Install_Helper::instance()->check_p
 							if ( check_is_responsive_pro_activated() ) {
 								?>
 							<span class="responsive-theme-feature-card responsive-theme-feature-card-pro"><span><?php esc_html_e( 'PRO', 'responsive' ); ?></span></span>
-								<?php
+							<?php
 							}
 							?>
+							<!-- WP-6871 This part add Free batch on Dashboard > Responsive Plus feature cards (no longer needed) -->
+							<!-- } else {
+								?>
+							<span class="responsive-theme-feature-card responsive-theme-feature-card-free"><span><?php // esc_html_e( 'FREE', 'responsive' ); ?></span></span>
+							?>	-->
 							<div class="responsive-theme-feature-card-title mt-2 mb-2"><?php echo esc_html_e( 'Woocommerce', 'responsive' ); ?></div>
 							<div class="responsive-theme-feature-card-desc"><?php echo esc_html_e( 'Adds enhanced set of options in the WooCommerce store customizer.', 'responsive' ); ?></div>
 							<?php

--- a/admin/templates/getting-started-home.php
+++ b/admin/templates/getting-started-home.php
@@ -201,7 +201,6 @@ $responsive_addons_state = Responsive_Plugin_Install_Helper::instance()->check_p
 
 	$responsive_addons_cards_content = array(
 		array(
-			'tag'   => 'free',
 			'title' => __( 'Starter Templates', 'responsive' ),
 			'desc'  => __( 'Unlock the library of 100+ Premium Starter Templates.', 'responsive' ),
 			'links' => array(
@@ -213,7 +212,6 @@ $responsive_addons_state = Responsive_Plugin_Install_Helper::instance()->check_p
 			),
 		),
 		array(
-			'tag'   => 'free',
 			'title' => __( 'White Label', 'responsive' ),
 			'desc'  => __( 'White Label the theme name & settings with the Pro Plugin.', 'responsive' ),
 			'links' => array(
@@ -397,12 +395,6 @@ $responsive_addons_state = Responsive_Plugin_Install_Helper::instance()->check_p
 								<span class="responsive-theme-feature-card responsive-theme-feature-card-<?php echo esc_html( $feature['tag'] ); ?>"><span><?php echo esc_html( $feature['tag'] ); ?></span></span>
 								<?php
 							}
-
-							if ( 'pro' !== $feature['tag'] ) {
-								?>
-								<span class="responsive-theme-feature-card responsive-theme-feature-card-<?php echo esc_html( $feature['tag'] ); ?>"><span><?php echo esc_html( $feature['tag'] ); ?></span></span>
-								<?php
-							}
 							?>
 							<div class="responsive-theme-feature-card-title mt-2 mb-2"><?php echo esc_html( $feature['title'] ); ?></div>
 							<div class="responsive-theme-feature-card-desc"><?php echo esc_html( $feature['desc'] ); ?></div>
@@ -475,10 +467,6 @@ $responsive_addons_state = Responsive_Plugin_Install_Helper::instance()->check_p
 							if ( check_is_responsive_pro_activated() ) {
 								?>
 							<span class="responsive-theme-feature-card responsive-theme-feature-card-pro"><span><?php esc_html_e( 'PRO', 'responsive' ); ?></span></span>
-								<?php
-							} else {
-								?>
-							<span class="responsive-theme-feature-card responsive-theme-feature-card-free"><span><?php esc_html_e( 'FREE', 'responsive' ); ?></span></span>
 								<?php
 							}
 							?>
@@ -671,10 +659,6 @@ $responsive_addons_state = Responsive_Plugin_Install_Helper::instance()->check_p
 							if ( check_is_responsive_pro_activated() ) {
 								?>
 							<span class="responsive-theme-feature-card responsive-theme-feature-card-pro"><span><?php esc_html_e( 'PRO', 'responsive' ); ?></span></span>
-								<?php
-							} else {
-								?>
-							<span class="responsive-theme-feature-card responsive-theme-feature-card-free"><span><?php esc_html_e( 'FREE', 'responsive' ); ?></span></span>
 								<?php
 							}
 							?>

--- a/core/includes/customizer/settings/class-responsive-customizer-notices.php
+++ b/core/includes/customizer/settings/class-responsive-customizer-notices.php
@@ -61,7 +61,6 @@ class Responsive_Customizer_Notices extends Responsive_Register_Customizer_Contr
 	public function add_controls() {
 		$this->register_types();
 		$this->add_docs_link_section();
-		$this->maybe_add_main_notice();
 		if(!responsive_is_user_pro()): 
 			$this->add_upsell_section();
 		endif;
@@ -144,47 +143,6 @@ class Responsive_Customizer_Notices extends Responsive_Register_Customizer_Contr
 				),
 				array(
 					'section' => 'responsive_info_woocommerce',
-					'type'    => 'hidden',
-				)
-			)
-		);
-	}
-
-	/**
-	 * Check for required plugins and add main notice if needed.
-	 */
-	private function maybe_add_main_notice() {
-		if ( class_exists( 'Responsive_Add_Ons', false ) ) {
-			return;
-		}
-
-		$this->add_section(
-			new Responsive_Customizer_Section(
-				'responsive_info_pro',
-				array(
-					'slug'        => 'responsive-add-ons',
-					'priority'    => 0,
-					'capability'  => 'install_plugins',
-					'hide_notice' => (bool) get_option( 'dismissed-responsive_info_pro', false ),
-					'title'       => __( 'Recommended Plugins', 'responsive' ),
-					'options'     => array(
-						'redirect' => admin_url( 'customize.php' ),
-					),
-					/* translators: Orbit Fox Companion */
-					'description' => sprintf( esc_html__( 'Get free access to 100+ ready-to-use Elementor & Block templates. Import a template, edit content and launch your website.', 'responsive' ), sprintf( '<strong>%s</strong>', 'Upgrade To Pro' ) ),
-				),
-				'Responsive_Main_Notice_Section'
-			)
-		);
-
-		$this->add_control(
-			new Responsive_Customizer_Control(
-				'responsive_control_to_enable_pro_recommendation',
-				array(
-					'sanitize_callback' => 'sanitize_text_field',
-				),
-				array(
-					'section' => 'responsive_info_pro',
 					'type'    => 'hidden',
 				)
 			)

--- a/core/includes/customizer/settings/class-responsive-customizer-notices.php
+++ b/core/includes/customizer/settings/class-responsive-customizer-notices.php
@@ -61,6 +61,9 @@ class Responsive_Customizer_Notices extends Responsive_Register_Customizer_Contr
 	public function add_controls() {
 		$this->register_types();
 		$this->add_docs_link_section();
+		/* WP-6805 This part is removed as it was calling a function to add install notice for
+		RSPT int the theme customizer no longer required */
+		// $this->maybe_add_main_notice();
 		if(!responsive_is_user_pro()): 
 			$this->add_upsell_section();
 		endif;
@@ -148,6 +151,49 @@ class Responsive_Customizer_Notices extends Responsive_Register_Customizer_Contr
 			)
 		);
 	}
+
+	/* WP-6805 This part is removed as it is the function to add install notice for
+	RSPT int the theme customizer no longer required */
+	// /**
+	//  * Check for required plugins and add main notice if needed.
+	//  */
+	// private function maybe_add_main_notice() {
+	// 	if ( class_exists( 'Responsive_Add_Ons', false ) ) {
+	// 		return;
+	// 	}
+
+	// 	$this->add_section(
+	// 		new Responsive_Customizer_Section(
+	// 			'responsive_info_pro',
+	// 			array(
+	// 				'slug'        => 'responsive-add-ons',
+	// 				'priority'    => 0,
+	// 				'capability'  => 'install_plugins',
+	// 				'hide_notice' => (bool) get_option( 'dismissed-responsive_info_pro', false ),
+	// 				'title'       => __( 'Recommended Plugins', 'responsive' ),
+	// 				'options'     => array(
+	// 					'redirect' => admin_url( 'customize.php' ),
+	// 				),
+	// 				/* translators: Orbit Fox Companion */
+	// 				'description' => sprintf( esc_html__( 'Get free access to 100+ ready-to-use Elementor & Block templates. Import a template, edit content and launch your website.', 'responsive' ), sprintf( '<strong>%s</strong>', 'Upgrade To Pro' ) ),
+	// 			),
+	// 			'Responsive_Main_Notice_Section'
+	// 		)
+	// 	);
+
+	// 	$this->add_control(
+	// 		new Responsive_Customizer_Control(
+	// 			'responsive_control_to_enable_pro_recommendation',
+	// 			array(
+	// 				'sanitize_callback' => 'sanitize_text_field',
+	// 			),
+	// 			array(
+	// 				'section' => 'responsive_info_pro',
+	// 				'type'    => 'hidden',
+	// 			)
+	// 		)
+	// 	);
+	// }
 
 	/**
 	 * Add View Pro Features section.

--- a/core/includes/functions.php
+++ b/core/includes/functions.php
@@ -251,8 +251,6 @@ if ( ! function_exists( 'responsive_setup' ) ) :
 			)
 		);
 
-		add_theme_support( 'custom-background' );
-
 		add_theme_support(
 			'custom-header',
 			array(

--- a/core/includes/functions.php
+++ b/core/includes/functions.php
@@ -250,6 +250,10 @@ if ( ! function_exists( 'responsive_setup' ) ) :
 				'footer-menu' => __( 'Footer Menu', 'responsive' ),
 			)
 		);
+		
+		/* WP-6540 - This part is commented out as it was overlaying the background image 
+		it was causing a bug when updating from 5.1.2 to 6.0.1, */
+		// add_theme_support( 'custom-background' );
 
 		add_theme_support(
 			'custom-header',


### PR DESCRIPTION
WP-6805 - Theme - Remove the RPST install notice in the theme customizer
WP-6871 - Remove "Free" badge in the Responsive > Dashboard from Responsive Plus feature cards.
WP-6540 - Responsive theme background image bug

## PR Request Template
### Common Checks
* [x] No PHPCS issues related to the files in the PR
* [x] Self-testing is done
* [x] Appropriate comments are added in the code
* [x] There are no error_log statements 
* [x] There are no unnecessary console log statements
* [x] Changelog is updated if required
* [x] Version no is updated if required
* [x] All best practices are followed, and code doesn't contain any deprecated code/methods
* [x] There are no console errors due to your code