### PR TITLE
Fix: Global Settings H2 font-color not working.

### DIFF
--- a/core/includes/customizer/assets/js/customize-preview-color-control.js
+++ b/core/includes/customizer/assets/js/customize-preview-color-control.js
@@ -201,11 +201,18 @@
     } );
 
     //H2 text Color
-    api( 'responsive_h2_text_color', function( value ) {
-        value.bind( function( newval ) {
-            $('h2').css('color', newval );
-        } );
-    } );
+    api('responsive_h2_text_color', function(value) {
+        value.bind(function(newval) {
+            $('h2').each(function() {
+                // Check if the <h2> is not inside an ancestor with the class "widget-area" or "site-title"
+                $isNotWidgetArea = $(this).closest('.widget-area').length === 0;
+                $isNotSiteTitle = $(this).closest('.site-title').length === 0
+                if ( $isNotSiteTitle && $isNotWidgetArea ) {
+                    $(this).css('color', newval);
+                }
+            });
+        });
+    });
 
     //H3 text Color
     api( 'responsive_h3_text_color', function( value ) {


### PR DESCRIPTION
Task ID - WP-6820, Global Settings > Typography
 > h2 typography and design > color not working.
The problem was in preview it was chaning sidebar
and page title color which is wrong.

## PR Request Template

### Common Checks
* [x] No PHPCS issues related to the files in the PR
* [x] Self-testing is done
* [x] Appropriate comments are added in the code
* [x] There are no error_log statements 
* [x] There are no unnecessary console log statements
* [x] Changelog is updated if required
* [x] Version no is updated if required
* [x] All best practices are followed, and code doesn't contain any deprecated code/methods
* [x] There are no console errors due to your code
