### PR TITLE
Fix the preview issue of font presets

### DIFF
--- a/core/includes/customizer/assets/js/customize-preview-font-presets.js
+++ b/core/includes/customizer/assets/js/customize-preview-font-presets.js
@@ -70,6 +70,38 @@
                 control.set('');
                 jQuery( 'style.customizer-typography-font-preset-body-font-family' ).remove();
                 jQuery( 'style.customizer-typography-font-preset-headings-font-family' ).remove();
+
+                 // Trigger body_typography[font-family] with its current value
+                var resetValues = ["body_typography[font-family]",
+                    "body_typography[font-weight]",
+                    "headings_typography[font-family]",
+                    "headings_typography[font-weight]",
+                    "heading_h1_typography[font-family]",
+                    "heading_h1_typography[font-weight]",
+                    "heading_h2_typography[font-family]",
+                    "heading_h2_typography[font-weight]",
+                    "heading_h3_typography[font-family]",
+                    "heading_h3_typography[font-weight]",
+                    "heading_h4_typography[font-family]",
+                    "heading_h4_typography[font-weight]",
+                    "heading_h5_typography[font-family]",
+                    "heading_h5_typography[font-weight]",
+                    "heading_h6_typography[font-family]",
+                    "heading_h6_typography[font-weight]",
+                    "meta_typography[font-family]",
+                    "meta_typography[font-weight]",
+                ];
+
+                resetValues.forEach(function (value) {
+                    var control = api(value);
+                    if (control) {
+                        var currentValue = control.get(); // Get the current value
+                        //if directly set to currentValue it will not trigger as it checks for change in value
+                        control.set("temp-value"); // Re-set to temp value so that it get triggered
+                        control.set(currentValue); // Re-set to trigger the bind logic
+                    }
+                });
+
                 return ;
             }
             var bodyFont = choices[value].bodyFont;
@@ -103,7 +135,7 @@
         jQuery( 'style.customizer-typography-font-preset-body-font-family' ).remove();
         jQuery( 'head' ).append(
             '<style class="customizer-typography-font-preset-body-font-family">'
-            + 'body' + '{ font-family:' + fontFamily +'; font-weight:' + fontWeight + ';}'
+            + 'body, .post-meta *' + '{ font-family:' + fontFamily +'; font-weight:' + fontWeight + ';}'
             + '</style>'
         );
     }

--- a/core/includes/customizer/custom-styles.php
+++ b/core/includes/customizer/custom-styles.php
@@ -5090,11 +5090,11 @@ function responsive_customizer_styles() {
 			responsive_enqueue_google_font($headingFontFamily);
 			$font_preset_css .= "
 			/* Font Preset */
-			body {
+			body, .post-meta * {
 				font-family: {$bodyFontFamily};
 				font-weight: {$bodyFontWeight};
 			}
-			h1, h2, h3, h4, h5, h6 {
+			h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 				font-family: {$headingFontFamily};
 				font-weight: {$headingFontWeight};
 			}";
@@ -5804,6 +5804,7 @@ function responsive_customizer_styles() {
 			";
 		}
 		wp_add_inline_style( 'responsive-woocommerce-style', apply_filters( 'responsive_head_css', responsive_minimize_css( $woocommerce_custom_css ) ) );
+		wp_add_inline_style('responsive-woocommerce-style', responsive_minimize_css($font_preset_css));
 	}
 }
 add_action( 'wp_enqueue_scripts', 'responsive_customizer_styles', 99 );


### PR DESCRIPTION
The previous font was not being applied to the preview when font presets reset button was used to reset the font. The fonts were not coming correctly in the frontend when the woocommerce plugin was active.

## PR Request Template

### Common Checks
* [ ] No PHPCS issues related to the files in the PR
* [ ] Self-testing is done
* [ ] Appropriate comments are added in the code
* [ ] There are no error_log statements 
* [ ] There are no unnecessary console log statements
* [ ] Changelog is updated if required
* [ ] Version no is updated if required
* [ ] All best practices are followed, and code doesn't contain any deprecated code/methods
* [ ] There are no console errors due to your code
