### PR TITLE
WP-7279 Fix nested menu items out of page bounds

### DIFF
--- a/core/includes/customizer/custom-styles.php
+++ b/core/includes/customizer/custom-styles.php
@@ -1494,6 +1494,18 @@ function responsive_customizer_styles() {
 	if ( 0 === $disable_mobile_menu ) {
 		$mobile_menu_breakpoint = 0;
 	}
+	// adding custom css when the menu is going out of the screen
+	$custom_css .= "
+		.main-navigation .children > li.focus > .children, .main-navigation .children > li.focus > .sub-menu-edge, .main-navigation .children > li:hover > .children, .main-navigation .children > li:hover > .sub-menu-edge,
+		.main-navigation .sub-menu > li.focus > .children,
+		.main-navigation .sub-menu > li.focus > .sub-menu-edge,
+		.main-navigation .sub-menu > li:hover > .children,
+		.main-navigation .sub-menu > li:hover > .sub-menu-edge,
+		.sub-menu .sub-menu-edge:hover {
+			left: auto !important;
+			right: 100%;
+			top: 0 !important;
+		}";
 
 	$custom_css .= "@media (min-width:{$mobile_menu_breakpoint}px) {
 		.main-navigation .menu-toggle {

--- a/core/includes/functions.php
+++ b/core/includes/functions.php
@@ -414,6 +414,8 @@ if ( ! function_exists( 'responsive_js' ) ) {
 		$mobile_menu_breakpoint = array( 'mobileBreakpoint' => get_theme_mod( 'responsive_mobile_menu_breakpoint', 767 ) );
 		wp_localize_script( 'navigation-scripts', 'responsive_breakpoint', $mobile_menu_breakpoint );
 
+		wp_enqueue_script('responsive_theme_nested_menus', get_template_directory_uri() . '/core/js/nested-menus.js', array('customize-preview'), RESPONSIVE_THEME_VERSION, true);
+
 	}
 }
 

--- a/core/js-dev/navigation.js
+++ b/core/js-dev/navigation.js
@@ -216,6 +216,12 @@
           } else {
               sub_menu.style.display = 'block';
           }
+		  sub_menu_edge = document.querySelectorAll( 'sub-menu-edge' );
+		  if ( sub_menu_edge.style.display == 'block' ) {
+			  sub_menu_edge.style.display = 'none';
+		  } else {
+			  sub_menu_edge.style.display = 'block';
+		  }
     }
     }
 

--- a/core/js/nested-menus.js
+++ b/core/js/nested-menus.js
@@ -3,7 +3,6 @@
   $(document).ready(function () {
     // Get all navigation toggle elements
     var navTOGGLE = document.querySelectorAll('.menu-item:not(.sub-menu .menu-item)');
-    console.log('this is navtoogle', navTOGGLE);
 
     // Exit if no navigation toggles are found
     if (!navTOGGLE.length) {

--- a/core/js/nested-menus.js
+++ b/core/js/nested-menus.js
@@ -1,0 +1,69 @@
+(function ($) {
+  "use strict";
+  $(document).ready(function () {
+    // Get all navigation toggle elements
+    var navTOGGLE = document.querySelectorAll('.menu-item:not(.sub-menu .menu-item)');
+    console.log('this is navtoogle', navTOGGLE);
+
+    // Exit if no navigation toggles are found
+    if (!navTOGGLE.length) {
+      return;
+    }
+
+    // Initialize submenu handling for each navigation toggle
+    for (let i = 0; i < navTOGGLE.length; i++) {
+      initEachNavToggleSubmenuInside(navTOGGLE[i]);
+    }
+
+    /**
+     * Get the offset position of an element
+     */
+    function getOffset(el) {
+      if (el instanceof HTMLElement) {
+        var rect = el.getBoundingClientRect();
+
+        return {
+          top: rect.top + window.pageYOffset,
+          left: rect.left + window.pageXOffset,
+        };
+      }
+
+      return {
+        top: null,
+        left: null,
+      };
+    }
+
+    /**
+     * Initialize submenu edge detection for a navigation element
+     */
+    function initEachNavToggleSubmenuInside(nav) {
+      var SUBMENUPARENTS = nav.querySelectorAll(".menu-item-has-children");
+
+      if (!SUBMENUPARENTS.length) {
+        return;
+      }
+
+      for (let i = 0; i < SUBMENUPARENTS.length; i++) {
+        const parentMenuItem = SUBMENUPARENTS[i];
+
+        // Handle verifying if navigation will go offscreen on mouseenter
+        parentMenuItem.addEventListener("mouseenter", function () {
+          var submenu = parentMenuItem.querySelector("ul.sub-menu");
+          if (submenu) {
+            var off = getOffset(submenu);
+            var l = off.left;
+            var w = submenu.offsetWidth;
+            var docW = window.innerWidth;
+
+            var isEntirelyVisible = l + w <= docW;
+
+            if (!isEntirelyVisible) {
+              submenu.classList.add("sub-menu-edge");
+            }
+          }
+        });
+      }
+    }
+  });
+})(jQuery);


### PR DESCRIPTION
Task ID: WP-7279

Fixed the issue where nested menu items were going out of the page bounds when the menu was too long. Added a new JS file to handle the nested menu items.

## PR Request Template

### Common Checks
* [ ] No PHPCS issues related to the files in the PR
* [ ] Self-testing is done
* [ ] Appropriate comments are added in the code
* [ ] There are no error_log statements 
* [ ] There are no unnecessary console log statements
* [ ] Changelog is updated if required
* [ ] Version no is updated if required
* [ ] All best practices are followed, and code doesn't contain any deprecated code/methods
* [ ] There are no console errors due to your code
